### PR TITLE
Mw add work sans lora fonts 49

### DIFF
--- a/src/styles/_global.scss
+++ b/src/styles/_global.scss
@@ -2,21 +2,31 @@
 @import "/src/styles/TechSkillLevels.scss";
 @import "/src/styles/TechStack.scss";
 
+@import url("https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,700;1,700&family=Work+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap");
+
 * {
   box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
+  font-family: "Work Sans", -apple-system, BlinkMacSystemFont, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background: rgb(207, 216, 220);
   background: linear-gradient(90deg, #cfd8dc 0%, #b0bec5 100%);
   width: 100%;
   height: 100vh;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: "Lora", serif;
+  font-weight: 700;
 }
 
 code {

--- a/src/styles/_global.scss
+++ b/src/styles/_global.scss
@@ -8,6 +8,10 @@
   box-sizing: border-box;
 }
 
+html {
+  font-size: 16px;
+}
+
 body {
   margin: 0;
   font-family: "Work Sans", -apple-system, BlinkMacSystemFont, sans-serif;
@@ -17,6 +21,7 @@ body {
   background: linear-gradient(90deg, #cfd8dc 0%, #b0bec5 100%);
   width: 100%;
   height: 100vh;
+  font-weight: 400;
 }
 
 h1,


### PR DESCRIPTION
# Imported Add Work Sans and Lora fonts
#49 
imported from Google Fonts the Work Sans sans-serif font and the Lora serif font; 
I added Work Sans to the body element, and I added Lora to headings elements h1 through h6 with a `font-weight` of 700 
set the body element font-weight to 400; 
gave the HTML element font-size of 16px; 
all fonts display in DOM fine, and they look kinda spectacular; 
Work Sans is one of the fonts that have the spacing where letters can respectful invade each other's personal space in a word; 
it's kinda amazing; 
check out the word DevTools, and you'll see how the capable T reaches over the lowercase v to keep the cold rain off the v's shoulder; 
it's a practical, functional, and caring typeface"

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Instructions


## ADDITION:
Added a "More Details" button on the Event Card.
Added styling to fall in-line with existing buttons.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works