### PR TITLE
mw-fix-Resume-techStack-with-skills-list-101 I changed the containing…

### DIFF
--- a/src/styles/TechSkillLevels.css
+++ b/src/styles/TechSkillLevels.css
@@ -13,14 +13,11 @@
 
 #tech-skill-levels__block .tech__list-item {
   border-block-end: #00000025 1px dashed;
-  flex: 0 1 240px;
 }
 
 #tech-skill-levels__block .tech__list {
-  display: flex;
-  flex-wrap: wrap;
-  flex-direction: row;
-  align-items: stretch;
-  grid-column-gap: 2rem;
-  grid-row-gap: 0.5rem;
+    grid-column-gap: 2rem;
+    grid-row-gap: 0.5rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
 }


### PR DESCRIPTION
# fixed the issue with messed up tech stack list items 

I changed the containing element of the techStack list to display Grid and gave the property grid-template-columns a value with auto-fill and minmax; now, the list items stack and wrap perfectly where they never shrink below 240px but they grow as much as they need to like flexbox would do it -- BOOM

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
